### PR TITLE
Fix test for learn page index

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -28,6 +28,7 @@
           :selected="inTopics"
         />
         <tab-link
+          name="exam-link"
           v-if="isUserLoggedIn && userHasMemberships"
           :title="$tr('exams')"
           icon="assignments"

--- a/kolibri/plugins/learn/assets/test/util/core-base.vue
+++ b/kolibri/plugins/learn/assets/test/util/core-base.vue
@@ -1,0 +1,7 @@
+<template>
+
+  <div>
+    <slot />
+  </div>
+
+</template>

--- a/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
@@ -1,16 +1,30 @@
 /* eslint-env mocha */
 const Vue = require('vue-test');
+const VueRouter = require('vue-router');
 const _ = require('lodash');
 const assert = require('assert');
 const LearnIndex = require('../../src/views/index.vue');
 const makeStore = require('../util/makeStore');
+const coreBase = require('../util/core-base.vue');
+
+const router = new VueRouter({
+  routes: [
+    { path: '/learn', name: 'LEARN_CHANNEL' },
+    { path: '/explore', name: 'EXPLORE_CHANNEL' },
+    { path: '/exams', name: 'EXAM_LIST' }
+  ]
+});
 
 function makeVm(options) {
   const Ctor = Vue.extend(LearnIndex);
-  // TODO not mounting the component, since I can't figure out how
-  // to setup tests to make all of the dependent components (namely core-base) work
-  // seems to be good enough for current tests
-  return new Ctor(options);
+  Object.assign(options, {
+    components: {
+      coreBase,
+      'explore-page': '<div>Explore Page</div>',
+    },
+    router,
+  });
+  return new Ctor(options).$mount();
 }
 
 describe('learn index', () => {

--- a/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
@@ -1,7 +1,6 @@
 /* eslint-env mocha */
 const Vue = require('vue-test');
 const VueRouter = require('vue-router');
-const _ = require('lodash');
 const assert = require('assert');
 const LearnIndex = require('../../src/views/index.vue');
 const makeStore = require('../util/makeStore');
@@ -27,10 +26,15 @@ function makeVm(options) {
   return new Ctor(options).$mount();
 }
 
+function getElements(vm) {
+  return {
+    examLink: () => vm.$el.querySelector('li[name="exam-link"]'),
+  };
+}
+
 describe('learn index', () => {
   let store;
 
-  const isExamTab = ({ title }) => title === 'Exams';
   const setSessionUserKind = (kind) => {
     store.state.core.session.kind = [kind];
   };
@@ -47,7 +51,8 @@ describe('learn index', () => {
     setSessionUserKind('learner');
     setMemberships([{ id: 'membership_1' }]);
     const vm = makeVm({ store });
-    assert(!_.isUndefined(_.find(vm.learnTabs, isExamTab)));
+    const { examLink } = getElements(vm);
+    assert(examLink() !== null);
   });
 
   it('the exam tab is not available if user is not logged in', () => {
@@ -55,13 +60,15 @@ describe('learn index', () => {
     setSessionUserKind('anonymous');
     setMemberships([]);
     const vm = makeVm({ store });
-    assert(_.isUndefined(_.find(vm.learnTabs, isExamTab)));
+    const { examLink } = getElements(vm);
+    assert(examLink() === null);
   });
 
   it('the exam tab is not available if user has no memberships/classes', () => {
     setSessionUserKind('learner');
     setMemberships([]);
     const vm = makeVm({ store });
-    assert(_.isUndefined(_.find(vm.learnTabs, isExamTab)));
+    const { examLink } = getElements(vm);
+    assert(examLink() === null);
   });
 });


### PR DESCRIPTION
To make the 'exam' tab visibility testable after these changes, I had to actually mount `learn-page`, which I had trouble doing earlier.

To finally address this, I created a mock of the `core-base` element, and injected a `router` instance into the test.

Finally, I added a `name` attr to the 'exam' tab to make it selectable, and then rewrote the tests.